### PR TITLE
Fix:育成論から呼び出すボタンの配色の変更、育成論詳細モーダルのCSSの調整 #19

### DIFF
--- a/src/components/Attacker.jsx
+++ b/src/components/Attacker.jsx
@@ -136,7 +136,7 @@ const Attacker = (props) => {
       <div className="artboard phone-5 bg-white rounded-lg shadow-xl mx-auto mt-10 ">
         <div className="flex flex-row bg-gradient-to-r rounded-t-lg from-red-200 to-red-200">
           <p className="pt-5 pl-5 font-bold ">攻撃側</p>
-          <CallPostModal />
+          <CallPostModal textColor={`text-rose-500`} />
         </div>
 
         {/* ポケモン選択　*/}

--- a/src/components/CallPostModal.jsx
+++ b/src/components/CallPostModal.jsx
@@ -1,11 +1,12 @@
 import React from "react";
 
-const CallPostModal = () => {
+const CallPostModal = (props) => {
   return (
     <>
       <label
         htmlFor={`call-post-modal`}
-        className="btn btn-primary ml-32 mt-2 mb-2"
+        // className="btn bg-white text-rose-500 hover:bg-yellow-100 ml-32 mt-2 mb-2"
+        className={`btn bg-white ${props.textColor} hover:bg-yellow-100 ml-32 mt-2 mb-2`}
       >
         育成論から呼び出す
       </label>

--- a/src/components/Defender.jsx
+++ b/src/components/Defender.jsx
@@ -131,7 +131,7 @@ const Defender = (props) => {
       <div className="artboard phone-5 bg-white rounded-lg shadow-xl mx-auto mt-10 ">
         <div className="flex flex-row bg-gradient-to-r rounded-t-lg from-blue-200 to-blue-200">
           <p className="pt-5 pl-5 font-bold ">防御側</p>
-          <CallPostModal />
+          <CallPostModal textColor={`text-indigo-500`} />
         </div>
 
         <div className="w-64 mt-5 ml-4">

--- a/src/components/PostCard.jsx
+++ b/src/components/PostCard.jsx
@@ -44,28 +44,40 @@ const PostShowModal = (props) => {
           >
             ✕
           </label>
-          <h3 className="font-bold text-lg col-span-2 justify-center">
+          <h3 className="font-bold text-lg col-span-2 flex justify-center mb-4">
             {props.post.title}
           </h3>
           <div className="grid grid-cols-4 gap-1">
-            <p className="col-span-2">ポケモン: {props.post.pokemon}</p>
-            <p className="col-span-2">性格: {props.post.nature}</p>
+            <p className="col-span-2">
+              <span class="font-bold">ポケモン:</span> {props.post.pokemon}
+            </p>
+            <p className="col-span-2">
+              <span class="font-bold">性格:</span> {props.post.nature}
+            </p>
             <div className=" col-span-2">
               {" "}
-              努力値: {props.post.ev_hp}-{props.post.ev_attack}-
-              {props.post.ev_defense}-{props.post.ev_special_attack}-
-              {props.post.ev_special_defense}-{props.post.ev_speed}
+              <span class="font-bold">努力値: </span>
+              {props.post.ev_hp}-{props.post.ev_attack}-{props.post.ev_defense}-
+              {props.post.ev_special_attack}-{props.post.ev_special_defense}-
+              {props.post.ev_speed}
             </div>
             <div className=" col-span-2">
-              テラスタイプ: {props.post.tera_type}
+              <span class="font-bold">テラスタイプ: </span>
+              {props.post.tera_type}
             </div>
-            <p className="col-span-2">もちもの: {props.post.item}</p>
-            <p className="col-span-2">とくせい: {props.post.ability}</p>
-            <p className="col-span-4 pt-4">わざ:</p>
-            <p className="col-span-1"> {props.post.move1}</p>
-            <p className="col-span-1"> {props.post.move2}</p>
-            <p className="col-span-1"> {props.post.move3}</p>
-            <p className="col-span-1"> {props.post.move4}</p>
+            <p className="col-span-2">
+              <span class="font-bold">もちもの: </span>
+              {props.post.item}
+            </p>
+            <p className="col-span-2">
+              <span class="font-bold">とくせい: </span>
+              {props.post.ability}
+            </p>
+            <p className="col-span-4 pt-4 font-bold">わざ:</p>
+            <p className="col-span-2 "> {props.post.move1}</p>
+            <p className="col-span-2"> {props.post.move2}</p>
+            <p className="col-span-2 "> {props.post.move3}</p>
+            <p className="col-span-2 "> {props.post.move4}</p>
           </div>
           <h4 className="pt-4">概要</h4>
           <p>{props.post.body}</p>


### PR DESCRIPTION
Why
デザインの改善

What
「育成論から呼び出す」ボタンの配色の変更
投稿詳細モーダルのCSSの調整