### PR TITLE
Add:攻撃側、防御側双方の育成論からのステータス呼び出し機能を追加

### DIFF
--- a/src/components/Attacker.jsx
+++ b/src/components/Attacker.jsx
@@ -182,6 +182,7 @@ const Attacker = (props) => {
           <CallPostModal
             textColor={`text-rose-500`}
             setInformation={getAttackerInformation}
+            callPostModalId={`attacker-call-post-modal`}
           />
         </div>
 

--- a/src/components/CallPostModal.jsx
+++ b/src/components/CallPostModal.jsx
@@ -34,20 +34,24 @@ const CallPostModal = (props) => {
   return (
     <>
       <label
-        htmlFor={`call-post-modal`}
+        htmlFor={`${props.callPostModalId}`}
         className={`btn bg-white ${props.textColor} hover:bg-yellow-100 ml-32 mt-2 mb-2`}
       >
         育成論から呼び出す
       </label>
 
       {/* モーダル　*/}
-      <input type="checkbox" id={`call-post-modal`} className="modal-toggle" />
+      <input
+        type="checkbox"
+        id={`${props.callPostModalId}`}
+        className="modal-toggle"
+      />
 
       <div className="modal sm:modal-middle ">
         <div className="modal-box">
           <div className="min-h-screen">
             <label
-              htmlFor={`call-post-modal`}
+              htmlFor={`${props.callPostModalId}`}
               className="btn btn-sm btn-circle absolute right-2 top-2"
             >
               ✕

--- a/src/components/Defender.jsx
+++ b/src/components/Defender.jsx
@@ -183,6 +183,7 @@ const Defender = (props) => {
           <CallPostModal
             textColor={`text-indigo-500`}
             setInformation={getDefenderInformation}
+            callPostModalId={`defender-call-post-modal`}
           />
         </div>
 


### PR DESCRIPTION
Why
防御側の育成論呼び出し機能の実装

What
CallPostModal内のmodalのidを、親コンポーネントから受け渡される形に変更