### PR TITLE
Add:育成論を呼び出した際、モーダルウインドウが自動で閉じるように変更 #24

### DIFF
--- a/src/components/CallPostModal.jsx
+++ b/src/components/CallPostModal.jsx
@@ -115,6 +115,7 @@ const CallPostModal = (props) => {
                           post={post.attributes}
                           setInformation={props.setInformation}
                           key={post.id}
+                          callPostModalId={props.callPostModalId}
                         />
                       ))}
                   </tbody>

--- a/src/components/Defender.jsx
+++ b/src/components/Defender.jsx
@@ -43,11 +43,6 @@ const Defender = (props) => {
     setItem(item);
   };
 
-  // const handleTeraType = (teraType) => {
-  //   props.setTeraType(teraType);
-  //   console.log(teraType);
-  // };
-
   function handleTeraType(selectedOption) {
     const value = selectedOption ? selectedOption.value : null;
     props.setTeraType(value);

--- a/src/components/TableBody.jsx
+++ b/src/components/TableBody.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const TableBody = ({ post, setInformation }) => {
+const TableBody = ({ post, setInformation, callPostModalId }) => {
   const handleClick = () => {
     setInformation(post);
   };
@@ -11,20 +11,26 @@ const TableBody = ({ post, setInformation }) => {
         scope="row"
         className="pl-2 py-2 font-medium text-gray-900 whitespace-nowrap "
       >
-        <label onClick={handleClick}>{post.pokemon}</label>
+        <label onClick={handleClick} htmlFor={`${callPostModalId}`}>
+          {post.pokemon}
+        </label>
       </th>
 
       <td className="pl-2 whitespace-nowrap">
-        <label onClick={handleClick}>
+        <label onClick={handleClick} htmlFor={`${callPostModalId}`}>
           {post.ev_hp}-{post.ev_attack}-{post.ev_defense}-
           {post.ev_special_attack}-{post.ev_special_defense}-{post.ev_speed}
         </label>
       </td>
       <td className="pl-2 whitespace-nowrap">
-        <label onClick={handleClick}>{post.nature}</label>
+        <label onClick={handleClick} htmlFor={`${callPostModalId}`}>
+          {post.nature}
+        </label>
       </td>
       <td className="pl-2 whitespace-nowrap">
-        <label onClick={handleClick}>{post.title}</label>
+        <label onClick={handleClick} htmlFor={`${callPostModalId}`}>
+          {post.title}
+        </label>
       </td>
     </tr>
   );

--- a/src/pages/IndexPosts.jsx
+++ b/src/pages/IndexPosts.jsx
@@ -24,7 +24,6 @@ const IndexPosts = () => {
     axios.get("/posts").then((res) => {
       setPosts(res.data.data);
       setFilteredPosts(res.data.data);
-      console.log(res.data.data);
     });
   }, []);
 

--- a/src/pages/NewPost.jsx
+++ b/src/pages/NewPost.jsx
@@ -202,7 +202,6 @@ const NewPost = () => {
 
     try {
       const response = await axios.post("/posts", data, config);
-      console.log(response.data);
       if (response.status === 200) {
         toast.success("育成論が投稿されました!");
         navigate("/");


### PR DESCRIPTION
Why
育成論のデータを呼び出した際モーダルウインドウが自動で閉じるように実装するため

What
TableBodyにまでモーダルのIDを継承し、各種テーブルの要素のlabelにモーダルのIDを設定