### PR TITLE
Fix:16文字以上のタイトルを投稿できないように修正 #26

### DIFF
--- a/src/pages/NewPost.jsx
+++ b/src/pages/NewPost.jsx
@@ -141,6 +141,11 @@ const NewPost = () => {
       return;
     }
 
+    if (title.length > 16) {
+      toast.error("タイトルは16文字以内で入力してください。");
+      return;
+    }
+
     if (!title || !pokemon || !ability || !nature || !move1 || !teraType) {
       // 必須項目に漏れがないかチェック
       toast.error("入力項目が不足しています。");


### PR DESCRIPTION
Why
長いタイトルにより利便性が劣化するのを防ぐため

What
16文字を超えるタイトルの投稿をできないようにバリデーションを追加