### PR TITLE
 Add:metaタグ、twitter:imageを追加 #7

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,7 @@
     <meta property="og:site_name" content="ポケカルキュレーター" />
     <meta property="og:image" content="%PUBLIC_URL%/OGPthumbnail.png" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:image" content="%PUBLIC_URL%/OGPthumbnail.png" />
 
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo_transparent.png" />
 


### PR DESCRIPTION
Why
Twitter OGP画像表示のため

What
index.htmlにメタタグを追加